### PR TITLE
fix: changed CATALOG_MICROFRONTEND_URL

### DIFF
--- a/tutormfe/patches/openedx-lms-development-settings
+++ b/tutormfe/patches/openedx-lms-development-settings
@@ -79,7 +79,7 @@ MFE_CONFIG["SCHEDULE_EMAIL_SECTION"] = True
 {% endif %}
 
 {% if get_mfe("catalog") %}
-CATALOG_MICROFRONTEND_URL = "http://{{ MFE_HOST }}:{{ get_mfe("catalog")["port"] }}/courses"
+CATALOG_MICROFRONTEND_URL = "http://{{ MFE_HOST }}:{{ get_mfe("catalog")["port"] }}/catalog"
 {% endif %}
 
 # Cors configuration

--- a/tutormfe/patches/openedx-lms-production-settings
+++ b/tutormfe/patches/openedx-lms-production-settings
@@ -80,7 +80,7 @@ MFE_CONFIG["SCHEDULE_EMAIL_SECTION"] = True
 {% endif %}
 
 {% if get_mfe("catalog") %}
-CATALOG_MICROFRONTEND_URL = "{% if ENABLE_HTTPS %}https://{% else %}http://{% endif %}{{ MFE_HOST }}/courses"
+CATALOG_MICROFRONTEND_URL = "{% if ENABLE_HTTPS %}https://{% else %}http://{% endif %}{{ MFE_HOST }}/catalog"
 {% endif %}
 
 LOGIN_REDIRECT_WHITELIST.append("{{ MFE_HOST }}")


### PR DESCRIPTION
**Description**

Fixed mistake in base path of Catalog MFE directory from `/course` to `/catalog`