### PR TITLE
chore: change repo/branch for frontend-app-catalog

### DIFF
--- a/tutormfe/plugin.py
+++ b/tutormfe/plugin.py
@@ -73,9 +73,9 @@ CORE_MFE_APPS: dict[str, MFE_ATTRS_TYPE] = {
         "port": 1995,
     },
     "catalog": {
-        "repository": "https://github.com/raccoongang/frontend-app-catalog.git",
+        "repository": "https://github.com/openedx/frontend-app-catalog.git",
         "port": 1998,
-        "version": "rg-tick/develop",
+        "version": "master",
     },
 }
 


### PR DESCRIPTION
### Summary
Change repo and branch for frontend-app-catalog

**From:**
https://github.com/raccoongang/frontend-app-catalog.git
rg-tick/develop

**To:**
https://github.com/openedx/frontend-app-catalog.git
master