### PR TITLE
chore: allow direct references in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,9 @@ Community = "https://discuss.openedx.org/tag/tutor-mfe"
 "Community (Tutor Core)" = "https://discuss.openedx.org/tag/tutor"
 
 # hatch-specific configuration
+[tool.hatch.metadata]
+allow-direct-references = true
+
 [tool.hatch.metadata.hooks.custom]
 path = ".hatch_build.py"
 


### PR DESCRIPTION
Adjust pyproject.toml to use direct github refs.
Related PR: https://github.com/raccoongang/tutor-mfe/pull/8